### PR TITLE
Update to address "tiller not found" error on Cloud Deploys

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,7 +109,7 @@ before_script:
       fi
     - helm install
          --namespace "${NAMESPACE}"
-         --name "${DEPLOYMENT_NAME}"
+         "${DEPLOYMENT_NAME}"
          $EXTRA_ARGS
          $IMAGE_ARGS
          $TAG_ARGS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,6 +66,7 @@ before_script:
     - env | grep TAG
     - echo Removing any previous deploys of "${DEPLOYMENT_NAME}"
     - helm ls --all "${DEPLOYMENT_NAME}" > /dev/null && helm delete --purge "${DEPLOYMENT_NAME}" || true
+    - helm repo add stable https://kubernetes-charts.storage.googleapis.com/
     - helm repo update
     - >
       if [ "$TARGET_PROJECT_NAME" == so ]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,6 +66,7 @@ before_script:
     - env | grep TAG
     - echo Removing any previous deploys of "${DEPLOYMENT_NAME}"
     - helm ls --all "${DEPLOYMENT_NAME}" > /dev/null && helm delete --purge "${DEPLOYMENT_NAME}" || true
+    - helm repo update
     - >
       if [ "$TARGET_PROJECT_NAME" == so ]; then
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ before_script:
          $TAG_ARGS
          "${CHART_REPO}"/"${CHART}"
          --wait
-         --timeout 3600
+         --timeout 60m
   artifacts:
     name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
     untracked: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ before_script:
       - ./data
 
 .cross-project: &cross-project
-  image: crosscloudci/debian-helm-kubectl:v2.14.3-v1.16.2
+  image: crosscloudci/debian-helm-kubectl:v3.2.4-v1.18.4
   stage: Cross-Project
   script:
     - echo "$KUBECONFIG" | base64 -d | tee ./kubeconfig >/dev/null
@@ -64,7 +64,6 @@ before_script:
     - kubectl get componentstatuses
     - env | grep IMAGE
     - env | grep TAG
-    - helm init --client-only
     - echo Removing any previous deploys of "${DEPLOYMENT_NAME}"
     - helm ls --all "${DEPLOYMENT_NAME}" > /dev/null && helm delete --purge "${DEPLOYMENT_NAME}" || true
     - >
@@ -125,7 +124,7 @@ before_script:
       - ./data
 
 e2e:
-  image: crosscloudci/debian-helm-kubectl:v2.13.1-v1.13.0
+  image: crosscloudci/debian-helm-kubectl:v3.2.4-v1.18.4
   stage: End-to-End
   script:
     - echo "$KUBECONFIG" | base64 -d | tee ./kubeconfig >/dev/null


### PR DESCRIPTION
Updates to address the "tiller not found" error:

 - Deploys are now passing in cidev; https://gitlab.cidev.cncf.ci/cncf/cross-project/-/jobs/191959
 - Helm version has been updated on docker images
 - Addressed deprecated flag --name
 - Added time unit to the --timeout arg
 - Added helm repo add stable since latest version does not default stable URL